### PR TITLE
Bug fix: imbalanced-learn dependency

### DIFF
--- a/ITMO_FS/__about__.py
+++ b/ITMO_FS/__about__.py
@@ -3,4 +3,4 @@ __all__ = ["__title__", "__uri__", "__version__"]
 __title__ = "ITMO_FS"
 __uri__ = "https://github.com/ctlab/ITMO_FS"
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ URL = 'https://github.com/ctlab/ITMO_FS'
 LICENSE = 'new BSD'
 DOWNLOAD_URL = 'https://github.com/ctlab/ITMO_FS'
 VERSION = about["__version__"],
-INSTALL_REQUIRES = ['numpy', 'scipy', 'scikit-learn', 'imblearn', 'qpsolvers']
+INSTALL_REQUIRES = ['numpy', 'scipy', 'scikit-learn', 'imbalanced-learn', 'qpsolvers']
 CLASSIFIERS = ['Intended Audience :: Science/Research',
                'Intended Audience :: Developers',
                'License :: OSI Approved',


### PR DESCRIPTION
- Updated setup.py with the correct dependency for imbalanced-learn: without this change an automatic dependency licenses check would fail because imblearn does not a licence, the name of the package is imbalanced-learn. imblearn is just an alias.
- Updated the version of the package as this change requires to push to PyPi a new version.

- [X] Bug fix (non-breaking change which fixes an issue)